### PR TITLE
fix icon not displaying in chrome extension menu

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,14 +23,14 @@
             "48": "images/icon-48.png",
             "128": "images/icon-128.png",
             "256": "images/icon-256.png"
-        },
-        "icons": {
-            "16": "images/icon-16.png",
-            "32": "images/icon-32.png",
-            "48": "images/icon-48.png",
-            "128": "images/icon-128.png",
-            "256": "images/icon-256.png"
         }
+    },
+    "icons": {
+        "16": "images/icon-16.png",
+        "32": "images/icon-32.png",
+        "48": "images/icon-48.png",
+        "128": "images/icon-128.png",
+        "256": "images/icon-256.png"
     },
     "manifest_version": 2
 }


### PR DESCRIPTION
- **What does this PR do?**
This PR is for issue #45 to fix the icons not displaying in the Chrome extension menu

- **Any background context you want to provide?**
In order to get the icons to display properly, the icons key/value pair needed to be moved outside of "browser_action", and into the root object

- **Screenshots and/or Live Demo**
![image](https://user-images.githubusercontent.com/11459569/66707505-8436ff80-ed0f-11e9-9424-7c10bd7caeed.png)

