### PR TITLE
Removed allFrames property from all calls to chrome.tabs.executeScrip…

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -30,7 +30,6 @@ chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
       deleteScroll.onclick = function(element) {
         chrome.tabs.executeScript(tabs[0].id, {
           file: "delete.js",
-          allFrames: true
         });
         window.close();
       };
@@ -40,7 +39,6 @@ chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
       getScroll.onclick = function(element) {
         chrome.tabs.executeScript(tabs[0].id, {
           file: "get.js",
-          allFrames: true
         });
         window.close();
       };
@@ -57,7 +55,6 @@ chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
     saveScroll.onclick = function(element) {
       chrome.tabs.executeScript(tabs[0].id, {
         file: "save.js",
-        allFrames: true
       });
       window.close();
     };


### PR DESCRIPTION
…t in popup.js

- **What does this PR do?**
This PR fixes #66 by removing the allFrames property, which causes the extension to break when a page has more than one frame. In the example given (https://www.theguardian.com/technology/2008/mar/09/blogs), the footer signup is in an iframe. This causes save.js to be executed once per frame, overwriting the original link to the article with a link to the iframe.


