### PR TITLE
Added License heading and shiled's io for devfolioco/scrroll-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You can visit the issues page to find some relevant issues to contribute to or f
 
 Also, if you have any doubts regarding any of the concepts or how to get started, feel free to drop me a message on [Twitter](https://twitter.com/psuranas) or the [Devfolio community Telegram group](https://t.me/devfolio).
 
+## License
+
+[![NPM](https://img.shields.io/github/license/devfolioco/scrroll-in)](https://github.com/devfolioco/scrroll-in/blob/master/LICENSE)
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):


### PR DESCRIPTION
- **What does this PR do?**
In this PR, license heading is added in  README.md file , also image with appropriate hyperlink.

- **Screenshots and/or Live Demo**
![Screenshot from 2020-10-02 19-15-18](https://user-images.githubusercontent.com/44585698/94928638-b672db80-04e3-11eb-88ea-c5ce95f2db8c.png)

