### PR TITLE
Clicking on any saved options will open a new tab

### DIFF
--- a/options.js
+++ b/options.js
@@ -47,7 +47,7 @@
           div.innerHTML =
             "<a href=" +
             url +
-            ">" +
+            " target='_blank'>" +
             title +
             "</a> " +
             "<div class='perc'>" +
@@ -58,7 +58,7 @@
           div.innerHTML =
             "<a href=" +
             url +
-            ">" +
+            " target='_blank'>" +
             title +
             "</a> " +
             "<div class='perc'>" +


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Whenever we click on a saved scrroll, instead of redirecting it to the destination it will now open a new tab with the required destination.
I'm not sure if this change is really required, but it's a small change so I considered working on it.


