### PR TITLE
Delete operation in every container problem solved issue#125

### DIFF
--- a/options.js
+++ b/options.js
@@ -1,7 +1,7 @@
 {
   const list = document.getElementById("saved-urls");
 
-  chrome.storage.local.get("scroll-mark", function(result) {
+  chrome.storage.local.get("scroll-mark", function (result) {
     const urls = result["scroll-mark"];
     let delay = 0.3;
     // if no saved scrolls are available
@@ -71,13 +71,17 @@
     }
 
     // function to open dropdown menu
-    const showDropdown = function(e) {
+    const showDropdown = function (e) {
+      const dropdowns = document.getElementsByClassName("dropdown-content");
+      for (let i = 0; i < dropdowns.length; i++) {
+        dropdowns[i].classList.remove("show_dropdown");
+      }
       const drop_id = this.id.substring(0, this.id.length - 1);
       document.getElementById(drop_id).classList.toggle("show_dropdown");
     };
 
     // function to close dropdown menu
-    const closeDropdown = function(e) {
+    const closeDropdown = function (e) {
       const dropdowns = document.getElementsByClassName("dropdown-content");
       if (e.target.className !== "dropdown") {
         for (let i = 0; i < dropdowns.length; i++) {
@@ -101,7 +105,7 @@
 
     // TODO: use the delete.js script instead
     // but that would require some modifications to the original delete functionality
-    const deleteScrollElement = function(element) {
+    const deleteScrollElement = function (element) {
       Swal.fire({
         title: "Are you sure?",
         text: "This scrroll would be removed from your collection.",
@@ -123,7 +127,7 @@
       });
     };
 
-    const deleteAllScrollElement = function(element) {
+    const deleteAllScrollElement = function (element) {
       Swal.fire({
         title: "Remove all Scrrolls?",
         text: "This action is not reversible!",
@@ -134,7 +138,7 @@
         confirmButtonText: "Delete All"
       }).then(result => {
         if (result.value) {
-          chrome.storage.local.set({ "scroll-mark": {} }, data => {});
+          chrome.storage.local.set({ "scroll-mark": {} }, data => { });
           window.location.reload();
         }
       });


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
This PR is a solution to the problem specified in issue #125 
The problem was when we click on dot elements on a particular link container and again when we click on dot elements on another link container we see that the delete option of first container should hide but its not hiding.
![screencast-nimbus-capture-2020 10 11-18_09_23](https://user-images.githubusercontent.com/48866201/95680456-91731c80-0bf7-11eb-8433-c469771d80e0.gif)
![2020-10-11 (3)](https://user-images.githubusercontent.com/48866201/95680493-d5feb800-0bf7-11eb-8cdc-af67fd771233.png)

- **Any background context you want to provide?**
So,I developed a solution for that problem in which clicking the dropdown of one container will hide the previous one.
So,Delete option will only be for the link container which was clicked latest.
I have attached a live demo for it.
- **Screenshots and/or Live Demo**
![part2answer](https://user-images.githubusercontent.com/48866201/95680522-0c3c3780-0bf8-11eb-8d6a-19708876efc6.gif)