### PR TITLE
Added Sort By Date functionality to link containers in issue #129

### DIFF
--- a/options.css
+++ b/options.css
@@ -9,6 +9,32 @@
   src: url("Roboto/Roboto-Bold.ttf") format("truetype");
 }
 
+input[type=text] {
+  padding: 10px;
+  font-size: 17px;
+  border: 1px solid grey;
+  float: left;
+  width: 80%;
+  background: #f1f1f1;
+}
+
+ button {
+  float: left;
+  width: 20%;
+  padding: 10px;
+  background: #2196F3;
+  color: white;
+  font-size: 17px;
+  border: 1px solid grey;
+  border-left: none;
+  cursor: pointer;
+}
+
+button {
+  background: #0b7dda;
+}
+
+
 body {
   background: url("./images/bg.jpg");
   /* background: #242a36; */

--- a/options.js
+++ b/options.js
@@ -1,7 +1,7 @@
 {
   const list = document.getElementById("saved-urls");
 
-  chrome.storage.local.get("scroll-mark", function(result) {
+  chrome.storage.local.get("scroll-mark", function (result) {
     const urls = result["scroll-mark"];
     let delay = 0.3;
     // if no saved scrolls are available
@@ -71,13 +71,17 @@
     }
 
     // function to open dropdown menu
-    const showDropdown = function(e) {
+    const showDropdown = function (e) {
+      const dropdowns = document.getElementsByClassName("dropdown-content");
+      for (let i = 0; i < dropdowns.length; i++) {
+        dropdowns[i].classList.remove("show_dropdown");
+      }
       const drop_id = this.id.substring(0, this.id.length - 1);
       document.getElementById(drop_id).classList.toggle("show_dropdown");
     };
 
     // function to close dropdown menu
-    const closeDropdown = function(e) {
+    const closeDropdown = function (e) {
       const dropdowns = document.getElementsByClassName("dropdown-content");
       if (e.target.className !== "dropdown") {
         for (let i = 0; i < dropdowns.length; i++) {
@@ -101,7 +105,7 @@
 
     // TODO: use the delete.js script instead
     // but that would require some modifications to the original delete functionality
-    const deleteScrollElement = function(element) {
+    const deleteScrollElement = function (element) {
       Swal.fire({
         title: "Are you sure?",
         text: "This scrroll would be removed from your collection.",
@@ -123,7 +127,7 @@
       });
     };
 
-    const deleteAllScrollElement = function(element) {
+    const deleteAllScrollElement = function (element) {
       Swal.fire({
         title: "Remove all Scrrolls?",
         text: "This action is not reversible!",
@@ -134,7 +138,7 @@
         confirmButtonText: "Delete All"
       }).then(result => {
         if (result.value) {
-          chrome.storage.local.set({ "scroll-mark": {} }, data => {});
+          chrome.storage.local.set({ "scroll-mark": {} }, data => { });
           window.location.reload();
         }
       });

--- a/options.js
+++ b/options.js
@@ -3,7 +3,10 @@
 
   chrome.storage.local.get("scroll-mark", function (result) {
     const urls = result["scroll-mark"];
+    console.log(urls);
     let delay = 0.3;
+    var listUrls = [];
+    var j = 0;
     // if no saved scrolls are available
     const heading = document.getElementById("saved-scroll-heading");
     if (Object.entries(urls).length === 0 && urls.constructor === Object) {
@@ -13,19 +16,27 @@
     } else {
       heading.innerHTML =
         "<h1 id='saved-scroll-heading'>All Saved Scrrolls</h1>";
+      const search = document.createElement("p");
 
       const btn = document.createElement("div");
+      search.innerHTML = "<p><input type='text' name='Search' placeholder='Search' id='searchtxt'/><button id='searchbtn'>Search </button></p>";
+
       btn.innerHTML = `
-      <div id="delete-button">
+      <div id="delete-button" data-filter="true">
         <div class="btn del" id="delete-all"> <img src='./images/bin.png'> </div>
       </div>
       `;
       const btn2 = document.createElement("button");
       btn2.innerHTML = "<button class='btn primary' id='sort-button'>Sort by Date </button>";
+      list.appendChild(search);
+
       document.body.appendChild(btn);
+      var i2 = 0;
       document.body.appendChild(btn2);
       for (var url in urls) {
         const title = urls[url].title || url;
+        listUrls[i2] = url;
+        i2 = i2 + 1;
         const url_id = url;
         const div = document.createElement("div");
         div.setAttribute("class", "Scroll");
@@ -70,6 +81,7 @@
         div.style.animationDelay = (delay += 0.1) + "s";
         list.appendChild(div);
       }
+      j = i2;
     }
 
     // function to open dropdown menu
@@ -105,6 +117,7 @@
     const scrollElements = document.getElementsByClassName("ScrollElement");
     const deleteAllBtn = document.getElementById("delete-all");
     const sortbutton = document.getElementById('sort-button');
+    const searchbtn = document.getElementById('searchbtn');
     // TODO: use the delete.js script instead
     // but that would require some modifications to the original delete functionality
     const deleteScrollElement = function (element) {
@@ -145,6 +158,124 @@
         }
       });
     };
+
+    const searchvalue = function (e) {
+
+      var string1 = document.getElementById("searchtxt").value;
+      while (list.firstChild) {
+        list.removeChild(list.firstChild);
+      }
+
+      //var listUrls = [];
+      j = 0;
+      for (var url in urls) {
+        title = urls[url].title;
+        console.log("title=", title);
+        var re = new RegExp(string1, 'gi');
+        //console.log(`/${string1}/g`);
+        var res = title.match(re);
+        if (res !== null) {
+          listUrls[j] = url;
+          j = j + 1;
+        }
+        console.log(res);
+      }
+      console.log("llist", listUrls);
+      for (var i = 0; i < j; i++) {
+        const url = listUrls[i];
+        const title = urls[url].title || url;
+        const url_id = url;
+        const div = document.createElement("div");
+        div.setAttribute("class", "Scroll");
+        div.setAttribute(
+          "data-date",
+          urls[url].date ? urls[url].date.slice(0, 15) : "Date-Here"
+        );
+        const percentage = Math.round(
+          (urls[url].offset / urls[url].total) * 100
+        );
+
+        const delete_html1 = `
+        <div class="dropdown" id="${url_id}_|_">
+          <div id="${url_id}_|" class="dropdown-content">
+                <button class="ScrollElement" id="${url_id}">Delete</button>
+          </div>
+        </div>
+        `;
+
+        if (percentage)
+          div.innerHTML =
+            "<a href=" +
+            url +
+            ">" +
+            title +
+            "</a> " +
+            "<div class='perc'>" +
+            percentage +
+            "</div>" +
+            delete_html1;
+        else
+          div.innerHTML =
+            "<a href=" +
+            url +
+            ">" +
+            title +
+            "</a> " +
+            "<div class='perc'>" +
+            0 +
+            "</div>" +
+            delete_html1;
+        div.style.animationDelay = (delay += 0.1) + "s";
+        list.appendChild(div);
+      }
+      const showDropdown1 = function (e) {
+        const dropdowns = document.getElementsByClassName("dropdown-content");
+        for (let i = 0; i < dropdowns.length; i++) {
+          dropdowns[i].classList.remove("show_dropdown");
+        }
+        const drop_id = this.id.substring(0, this.id.length - 1);
+        document.getElementById(drop_id).classList.toggle("show_dropdown");
+      };
+
+      // function to close dropdown menu
+      const closeDropdown1 = function (e) {
+        const dropdowns = document.getElementsByClassName("dropdown-content");
+        if (e.target.className !== "dropdown") {
+          for (let i = 0; i < dropdowns.length; i++) {
+            dropdowns[i].classList.remove("show_dropdown");
+          }
+        }
+      };
+      const dotElements1 = document.getElementsByClassName("dropdown");
+
+      for (let i = 0; i < dotElements1.length; i++) {
+        dotElements1[i].addEventListener("click", showDropdown1, false);
+      }
+
+      const containers1 = document.getElementsByClassName("container");
+      containers1[0].addEventListener("click", closeDropdown1);
+
+      const scrollElements1 = document.getElementsByClassName("ScrollElement");
+      const deleteAllBtn1 = document.getElementById("delete-all");
+      const sortbutton = document.getElementById('sort-button');
+      const searchbtn = document.getElementById('searchbtn');
+      for (let i = 0; i < scrollElements1.length; i++) {
+        scrollElements1[i].addEventListener("click", deleteScrollElement, false);
+      }
+      if (deleteAllBtn1) {
+        deleteAllBtn1.addEventListener("click", deleteAllScrollElement, false);
+      }
+      if (sortbutton) {
+        sortbutton.addEventListener("click", sortbydate, false);
+      }
+      if (searchbtn) {
+        searchbtn.addEventListener("click", searchvalue, false);
+      }
+
+
+      //console.log(listUrls);
+      //alert(string1);
+    }
     const sortbydate = function (e) {
       //console.log("list=", list);
 
@@ -155,8 +286,10 @@
       //alert("sort by date");
       var obj = [];
       i = 0;
-      for (var url in urls) {
+      console.log(listUrls);
+      for (var i3 = 0; i3 < j; i3++) {
         //console.log(url);
+        url = listUrls[i3];
         obj[i] = urls[url];
         obj[i].url = url;
         i = i + 1;
@@ -169,7 +302,7 @@
         return new Date(a.date) - new Date(b.date);
       });
       //console.log("obj", obj);
-      var listUrls = [];
+      //var listUrls = [];
       //console.log(listUrls);
 
       //const urls2 = new Object();
@@ -181,7 +314,7 @@
       }
       //console.log(listUrls);
 
-      for (var i = 0; i < listUrls.length; i++) {
+      for (var i = 0; i < i1; i++) {
         const url = listUrls[i];
         const title = urls[url].title || url;
         const url_id = url;
@@ -259,7 +392,7 @@
       const scrollElements1 = document.getElementsByClassName("ScrollElement");
       const deleteAllBtn1 = document.getElementById("delete-all");
       const sortbutton = document.getElementById('sort-button');
-
+      const searchbtn = document.getElementById('searchbtn');
       for (let i = 0; i < scrollElements1.length; i++) {
         scrollElements1[i].addEventListener("click", deleteScrollElement, false);
       }
@@ -268,6 +401,9 @@
       }
       if (sortbutton) {
         sortbutton.addEventListener("click", sortbydate, false);
+      }
+      if (searchbtn) {
+        searchbtn.addEventListener("click", searchvalue, false);
       }
     }
 
@@ -279,6 +415,9 @@
     }
     if (sortbutton) {
       sortbutton.addEventListener("click", sortbydate, false);
+    }
+    if (searchbtn) {
+      searchbtn.addEventListener("click", searchvalue, false);
     }
   });
 }

--- a/options.js
+++ b/options.js
@@ -20,8 +20,10 @@
         <div class="btn del" id="delete-all"> <img src='./images/bin.png'> </div>
       </div>
       `;
+      const btn2 = document.createElement("button");
+      btn2.innerHTML = "<button class='btn primary' id='sort-button'>Sort by Date </button>";
       document.body.appendChild(btn);
-
+      document.body.appendChild(btn2);
       for (var url in urls) {
         const title = urls[url].title || url;
         const url_id = url;
@@ -102,7 +104,7 @@
 
     const scrollElements = document.getElementsByClassName("ScrollElement");
     const deleteAllBtn = document.getElementById("delete-all");
-
+    const sortbutton = document.getElementById('sort-button');
     // TODO: use the delete.js script instead
     // but that would require some modifications to the original delete functionality
     const deleteScrollElement = function (element) {
@@ -143,12 +145,140 @@
         }
       });
     };
+    const sortbydate = function (e) {
+      //console.log("list=", list);
+
+      while (list.firstChild) {
+        list.removeChild(list.firstChild);
+      }
+      //console.log("list=", list);
+      //alert("sort by date");
+      var obj = [];
+      i = 0;
+      for (var url in urls) {
+        //console.log(url);
+        obj[i] = urls[url];
+        obj[i].url = url;
+        i = i + 1;
+        //console.log(urls[url]);
+      }
+
+      obj.sort(function (a, b) {
+        // Turn your strings into dates, and then subtract them
+        // to get a value that is either negative, positive, or zero.
+        return new Date(a.date) - new Date(b.date);
+      });
+      //console.log("obj", obj);
+      var listUrls = [];
+      //console.log(listUrls);
+
+      //const urls2 = new Object();
+      for (var i1 = 0; i1 < obj.length;) {
+        listUrls[i1] = obj[i1].url;
+        i1 = i1 + 1;
+        //console.log("urls=", obj[i].url);
+        //urls2[obj[i].url] = obj[i];
+      }
+      //console.log(listUrls);
+
+      for (var i = 0; i < listUrls.length; i++) {
+        const url = listUrls[i];
+        const title = urls[url].title || url;
+        const url_id = url;
+        const div = document.createElement("div");
+        div.setAttribute("class", "Scroll");
+        div.setAttribute(
+          "data-date",
+          urls[url].date ? urls[url].date.slice(0, 15) : "Date-Here"
+        );
+        const percentage = Math.round(
+          (urls[url].offset / urls[url].total) * 100
+        );
+
+        const delete_html1 = `
+        <div class="dropdown" id="${url_id}_|_">
+          <div id="${url_id}_|" class="dropdown-content">
+                <button class="ScrollElement" id="${url_id}">Delete</button>
+          </div>
+        </div>
+        `;
+
+        if (percentage)
+          div.innerHTML =
+            "<a href=" +
+            url +
+            ">" +
+            title +
+            "</a> " +
+            "<div class='perc'>" +
+            percentage +
+            "</div>" +
+            delete_html1;
+        else
+          div.innerHTML =
+            "<a href=" +
+            url +
+            ">" +
+            title +
+            "</a> " +
+            "<div class='perc'>" +
+            0 +
+            "</div>" +
+            delete_html1;
+        div.style.animationDelay = (delay += 0.1) + "s";
+        list.appendChild(div);
+      }
+      //console.log("finallist", list);
+      const showDropdown1 = function (e) {
+        const dropdowns = document.getElementsByClassName("dropdown-content");
+        for (let i = 0; i < dropdowns.length; i++) {
+          dropdowns[i].classList.remove("show_dropdown");
+        }
+        const drop_id = this.id.substring(0, this.id.length - 1);
+        document.getElementById(drop_id).classList.toggle("show_dropdown");
+      };
+
+      // function to close dropdown menu
+      const closeDropdown1 = function (e) {
+        const dropdowns = document.getElementsByClassName("dropdown-content");
+        if (e.target.className !== "dropdown") {
+          for (let i = 0; i < dropdowns.length; i++) {
+            dropdowns[i].classList.remove("show_dropdown");
+          }
+        }
+      };
+      const dotElements1 = document.getElementsByClassName("dropdown");
+
+      for (let i = 0; i < dotElements1.length; i++) {
+        dotElements1[i].addEventListener("click", showDropdown1, false);
+      }
+
+      const containers1 = document.getElementsByClassName("container");
+      containers1[0].addEventListener("click", closeDropdown1);
+
+      const scrollElements1 = document.getElementsByClassName("ScrollElement");
+      const deleteAllBtn1 = document.getElementById("delete-all");
+      const sortbutton = document.getElementById('sort-button');
+
+      for (let i = 0; i < scrollElements1.length; i++) {
+        scrollElements1[i].addEventListener("click", deleteScrollElement, false);
+      }
+      if (deleteAllBtn1) {
+        deleteAllBtn1.addEventListener("click", deleteAllScrollElement, false);
+      }
+      if (sortbutton) {
+        sortbutton.addEventListener("click", sortbydate, false);
+      }
+    }
 
     for (let i = 0; i < scrollElements.length; i++) {
       scrollElements[i].addEventListener("click", deleteScrollElement, false);
     }
     if (deleteAllBtn) {
       deleteAllBtn.addEventListener("click", deleteAllScrollElement, false);
+    }
+    if (sortbutton) {
+      sortbutton.addEventListener("click", sortbydate, false);
     }
   });
 }

--- a/popup.js
+++ b/popup.js
@@ -7,7 +7,7 @@ import {
 const root = document.getElementById("root");
 root.innerHTML = "<div> Loading...</div>";
 
-window.addEventListener("click", function(e) {
+window.addEventListener("click", function (e) {
   if (e.target.href !== undefined) {
     chrome.tabs.create({ url: e.target.href });
     chrome.storage.local.set({ "scroll-mark-shortcut-tip": true });
@@ -49,14 +49,14 @@ chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
       `;
       let deleteScroll = document.getElementById("deleteScroll");
 
-      deleteScroll.onclick = function(element) {
+      deleteScroll.onclick = function (element) {
         executeDeleteScroll(tabs[0].id);
         window.close();
       };
 
       let getScroll = document.getElementById("getScroll");
 
-      getScroll.onclick = function(element) {
+      getScroll.onclick = function (element) {
         executeGetScroll(tabs[0].id);
         window.close();
       };
@@ -70,7 +70,7 @@ chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
     }
     let saveScroll = document.getElementById("saveScroll");
 
-    saveScroll.onclick = function(element) {
+    saveScroll.onclick = function (element) {
       executeSaveScroll(tabs[0].id);
       window.close();
     };


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
In this pull request , I have solved the issue specified in issue #129 .
The link containers were scattered .So, its difficult to find the link for a particular date.
![2020-10-12](https://user-images.githubusercontent.com/48866201/95720621-1d845300-0c8f-11eb-8b6b-1a3a26e1ddc8.png)
Whenever we see the links page in settings, we see that the link containers are arranged in any order irrespective of their dates which becomes difficult to locate when we want to know which page we had saved in past.
- **Any background context you want to provide?**
So, I have coded a solution for this.I provided a 'Sort By Date' button to users.So, whenever the user clicks on this button all the link containers will be sorted and displayed on the page.
- **Screenshots and/or Live Demo**
Screenshot- All link containers sorted by date.
![2020-10-12 (1)](https://user-images.githubusercontent.com/48866201/95720554-08a7bf80-0c8f-11eb-94b5-a477096d9dcc.png)
Demo- Whole working
![sortbydate](https://user-images.githubusercontent.com/48866201/95720925-810e8080-0c8f-11eb-8096-34db55520a0c.gif)

So,
@prateek3255 
I have solved the problem as specified in the issue and also attached screenshots and live demo.

