### PR TITLE
Added Context Saving functionality to recollect back to the point

### DIFF
--- a/get.js
+++ b/get.js
@@ -8,6 +8,9 @@
       const scrollMarkOffset =
         scrollMarkData[url].offset || scrollMarkData[url];
       window.scrollTo({ left: 0, top: scrollMarkOffset, behavior: "smooth" });
+      if (document.readyState === "complete" && scrollMarkData[url].note !== undefined && scrollMarkData[url].note !== null) {
+        alert("We hope you recollect from here :)\n" + scrollMarkData[url].note);
+      }
     }
   });
 }

--- a/save.js
+++ b/save.js
@@ -1,7 +1,7 @@
 {
   const fullUrl = window.location.href;
   const url = fullUrl.split("?")[0];
-
+  var note = prompt("Enter the context:");
   chrome.storage.local.get("scroll-mark", data => {
     const scrollMarkData = data["scroll-mark"];
     const offset = window.pageYOffset;
@@ -9,8 +9,8 @@
     const title = document.title;
     let date = String(new Date());
     const newData = scrollMarkData
-      ? { ...scrollMarkData, [url]: { offset, total, title, date } }
-      : { [url]: { offset, total, title, date } };
+      ? { ...scrollMarkData, [url]: { offset, total, title, date, note } }
+      : { [url]: { offset, total, title, date, note } };
     chrome.storage.local.set({ "scroll-mark": newData }, () => {
       chrome.runtime.sendMessage("setActive");
     });


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->
**Problem Statement**
The core functionality of scrroll is to save the scrrolls of the web page and land the user to that scroll when surfing that page again.
But there is a slight catch.
Suppose the user saves the scrrolls of 20-30 pages every day so there is a very high possibility that the user can forget the context which he/she was thinking when surfing for the first time.
Scroll will only land the user to a particular part of the page but it will not give any context where the user had left before.

- **What does this PR do?**
1)I have worked on an innovative feature that is context saving of particular page.
2)Whenever the user wants to save the scrroll of a page, he/she is given the option to save the context or add some tags regarding the thought process of that particular topic via prompt box on that page.
3)Now, after entering into the prompt box the context will be saved in local storage.

![image](https://user-images.githubusercontent.com/48866201/97676268-65401280-1ab6-11eb-8884-19d200df3e48.png)

4)Now,when user will land back to that page he/she will be alerted about the context to recollect back.

![image](https://user-images.githubusercontent.com/48866201/97676378-91f42a00-1ab6-11eb-88da-c27deb3451b7.png)

5)This will help user recollect the thought process again.
6)This will be a great feature for this extension.

- **Screenshots and/or Live Demo**

![contextsavingscrroll (2)](https://user-images.githubusercontent.com/48866201/97677364-2743ee00-1ab8-11eb-9fd2-bd32c8a5f2af.gif)

@prateek3255 
I have worked on this issue #143 .
It works very great.
Can you review this?
